### PR TITLE
feat: automate dates screen for ios

### DIFF
--- a/tests/common/strings.py
+++ b/tests/common/strings.py
@@ -381,4 +381,7 @@ CALENDAR_EVENTS_ALERT_TITLE = '“edX - DemoX” has been added to your phone\'s
 CALENDAR_EVENTS_ALERT_VIEW_BUTTON = 'VIEW EVENTS'
 CALENDAR_EVENTS_ALERT_DONE_BUTTON = 'DONE'
 REMOVE_CALENDAR_EVENTS_TITLE = 'Remove calendar “edX - DemoX”'
-REMOVE_CALENDAR_EVENTS_MESSAGE = 'Would you like to remove the edX calendar “edX - DemoX” ?'
+DATES_COURSE_BANNER_INFO_IOS = ('We\'ve built a suggested schedule to help you stay on track. '
+                                'But don\'t worry—it\'s flexible so you can learn at your own pace. '
+                                'If you happen to fall behind on our suggested dates, '
+                                'you\'ll be able to adjust them to keep yourself on track.')

--- a/tests/common/strings.py
+++ b/tests/common/strings.py
@@ -381,6 +381,7 @@ CALENDAR_EVENTS_ALERT_TITLE = '“edX - DemoX” has been added to your phone\'s
 CALENDAR_EVENTS_ALERT_VIEW_BUTTON = 'VIEW EVENTS'
 CALENDAR_EVENTS_ALERT_DONE_BUTTON = 'DONE'
 REMOVE_CALENDAR_EVENTS_TITLE = 'Remove calendar “edX - DemoX”'
+REMOVE_CALENDAR_EVENTS_MESSAGE = 'Would you like to remove the edX calendar “edX - DemoX” ?'
 DATES_COURSE_BANNER_INFO_IOS = ('We\'ve built a suggested schedule to help you stay on track. '
                                 'But don\'t worry—it\'s flexible so you can learn at your own pace. '
                                 'If you happen to fall behind on our suggested dates, '

--- a/tests/ios/pages/ios_elements.py
+++ b/tests/ios/pages/ios_elements.py
@@ -6,6 +6,7 @@ all_buttons = 'XCUIElementTypeButton'
 all_textviews = 'XCUIElementTypeStaticText'
 all_pickwheels = 'XCUIElementTypePickerWheel'
 all_otherviews = 'XCUIElementTypeOther'
+all_textview_type = 'XCUIElementTypeTextView'
 
 # NEW LOGISTRATION SCREEN
 new_logistration_logo = 'StartUpViewController:logo-image-view'
@@ -266,7 +267,7 @@ create_post_question_label = 'DiscussionNewPostViewController:content-title-labe
 create_post_question_text_field = 'DiscussionNewPostViewController:content-text-view'
 create_post_add_post_button = 'DiscussionNewPostViewController:post-button'
 
-# DISCUSSION DETAILs SCREEN
+# DISCUSSION DETAILS SCREEN
 discussion_post_title_label = 'PostTableViewCell:title-label'
 discssion__author_text_view = 'DiscussionPostCell:author-button'
 discssion_number_responses = 'DiscussionPostCell:response-count-label'
@@ -279,3 +280,7 @@ discussion_details_report_button = 'DiscussionPostCell:report-button'
 discussion_details_add_response_button = 'DiscussionResponsesViewController:add-response-button'
 discussion_details_add_new_response = 'Add a response'
 discussion_details_status_message = 'StatusMessageView:message-label'
+
+# DATES SCREEN
+dates_banner_title = 'CourseDatesHeaderView:label-course-schedule'
+dates_banner_info = 'CourseDatesHeaderView:label-course-dates-description'

--- a/tests/ios/tests/test_ios_course_dates.py
+++ b/tests/ios/tests/test_ios_course_dates.py
@@ -1,0 +1,91 @@
+"""
+    Course Dates Test Module
+"""
+
+
+from tests.common import strings
+from tests.common.globals import Globals
+from tests.ios.pages.ios_main_dashboard import IosMainDashboard
+from tests.ios.pages.ios_my_courses_list import IosMyCoursesList
+from tests.ios.pages.ios_course_dashboard import IosCourseDashboard
+from tests.ios.pages.ios_course_resources import IosCourseResources
+from tests.ios.pages.ios_login_smoke import IosLoginSmoke
+from tests.ios.pages.ios_discussions_dashboard import IosDiscussionsDashboard
+from tests.ios.pages import ios_elements
+
+
+class TestIosCourseDates(IosLoginSmoke):
+    """
+    Course Dates screen's Test Case
+
+    """
+
+    def test_validate_ui_elements_smoke(self, set_capabilities, setup_logging):
+        """
+        Scenarios:
+        Verify that Course Dates screen will show following contents,
+        Header contents,
+            Back icon,
+            "Important Dates" as Title Date
+            Share icon to share specific date
+            Information about specific dates,
+        Verify that user should be able to view these contents:
+            Dates banner title,
+            Dates banner information
+            Dates start date
+            Dates start title
+        Verify all screen contents have their default values
+        """
+
+        global_contents = Globals(setup_logging)
+        ios_discussions_page = IosDiscussionsDashboard(set_capabilities, setup_logging)
+        ios_main_dashboard_page = IosMainDashboard(set_capabilities, setup_logging)
+        ios_course_dashboard_page = IosCourseDashboard(set_capabilities, setup_logging)
+        ios_my_courses_list = IosMyCoursesList(set_capabilities, setup_logging)
+        ios_course_resources_page = IosCourseResources(set_capabilities, setup_logging)
+
+        assert ios_main_dashboard_page.get_drawer_icon().text == strings.MAIN_DASHBOARD_NAVIGATION_MENU_NAME
+        if ios_my_courses_list.get_my_courses_list_row():
+            course_name = ios_my_courses_list.get_my_courses_list_row().text
+            assert ios_my_courses_list.load_course_details_screen().text in course_name
+
+        assert ios_course_dashboard_page.get_dates_tab().text == strings.COURSE_DASHBOARD_DATES_TAB
+        ios_course_dashboard_page.load_dates_tab()
+
+        assert ios_course_dashboard_page.get_share_icon().text == strings.COURSE_DASHBOARD_SHARE_COURSE
+        assert ios_course_resources_page.get_subsection_title()[0].text == strings.DATES_HEADER_TITLE
+        assert ios_course_resources_page.get_navigation_back_icon()[0].text == 'Courses'
+        assert ios_course_dashboard_page.get_share_icon().text == strings.COURSE_DASHBOARD_SHARE_COURSE
+        banner_title = global_contents.get_element_by_id(
+            set_capabilities,
+            ios_elements.dates_banner_title)
+        assert banner_title.text == strings.DATES_COURSE_BANNER_TITLE
+
+        banner_info = global_contents.get_element_by_id(
+            set_capabilities,
+            ios_elements.dates_banner_info)
+        assert banner_info.text == strings.DATES_COURSE_BANNER_INFO_IOS
+
+        all_text = global_contents.get_all_views_on_ios_screen(
+            set_capabilities,
+            ios_elements.all_textview_type
+        )
+
+        assert all_text[1].text == strings.DATES_COURSE_STARTS_TITLE
+
+    def test_sign_out_smoke(self, set_capabilities, setup_logging):
+        """
+        Scenarios:
+            Verify that user can logout from course dashboard screen
+        """
+
+        global_contents = Globals(setup_logging)
+        ios_main_dashboard_page = IosMainDashboard(set_capabilities, setup_logging)
+        set_capabilities.back()
+        assert ios_main_dashboard_page.load_account_screen().text == strings.PROFILE_SCREEN_TITLE
+        assert ios_main_dashboard_page.log_out().text == strings.LOGIN
+        assert ios_main_dashboard_page.load_ios_landing_page(
+            set_capabilities, setup_logging).text == strings.NEW_LANDING_MESSAGE_IOS
+
+        setup_logging.info('{} is successfully logged out'.format(global_contents.login_user_name))
+        setup_logging.info('-- Ending Test Case --')

--- a/tests/ios/tests/test_ios_course_dates.py
+++ b/tests/ios/tests/test_ios_course_dates.py
@@ -10,7 +10,6 @@ from tests.ios.pages.ios_my_courses_list import IosMyCoursesList
 from tests.ios.pages.ios_course_dashboard import IosCourseDashboard
 from tests.ios.pages.ios_course_resources import IosCourseResources
 from tests.ios.pages.ios_login_smoke import IosLoginSmoke
-from tests.ios.pages.ios_discussions_dashboard import IosDiscussionsDashboard
 from tests.ios.pages import ios_elements
 
 
@@ -38,7 +37,6 @@ class TestIosCourseDates(IosLoginSmoke):
         """
 
         global_contents = Globals(setup_logging)
-        ios_discussions_page = IosDiscussionsDashboard(set_capabilities, setup_logging)
         ios_main_dashboard_page = IosMainDashboard(set_capabilities, setup_logging)
         ios_course_dashboard_page = IosCourseDashboard(set_capabilities, setup_logging)
         ios_my_courses_list = IosMyCoursesList(set_capabilities, setup_logging)


### PR DESCRIPTION
[LEARNER-7801](https://2u-internal.atlassian.net/browse/LEARNER-7801)

**Description**

Followings features/stories will be implemented:
Verify that Course Dates screen will show following contents,
Header contents,
Back icon,
"Important Dates" as Title Date
Share icon to share specific date
Information about specific dates,
Verify that user should be able to view these contents:
Dates banner title,
Dates banner information
Dates start date
Dates start title
Verify all screen contents have their default values